### PR TITLE
Deprecate: scrape-login no longer works; point to official API + alexa-remote2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,44 @@
 # alexa-reminders
-A nodejs library to create Amazon Echo Alexa Reminders
 
-### This librabry can also be used as a pseudo Push Notification alternative.
-Read more about why [here](http://theappslab.com/2017/12/08/alexa-push-notifications-via-reminders/)
+> [!WARNING]
+> **Deprecated / no longer functional (as of 2026).** This library is kept for
+> historical reference only. Please use one of the [modern alternatives](#modern-alternatives) below.
 
-#### Installation
-```sh
-$ npm install -S alexa-reminders
-```
+A Node.js library (circa 2017) to create Amazon Echo / Alexa reminders — built
+back when there was **no** official reminders API, as a pseudo push-notification
+hack ([original write-up](http://theappslab.com/2017/12/08/alexa-push-notifications-via-reminders/)).
 
-#### Usage
-```javascript
-var reminders = require('alexa-reminders')
+## Why it no longer works
 
-reminders.login('Device Name', 'username', 'password', function(error, response, config){
-  reminders.setReminder('Ask Alexa team for a proper Reminders API', null, config, function(error, response){
-    console.log(response)
-  })
-})
-```
-### Listener
-Use a listener server to listen for calls from services such as IFTTT
-[https://github.com/noelportugal/alexa-reminders-listener](https://github.com/noelportugal/alexa-reminders-listener)
+It logged in by **scripting the `alexa.amazon.com` sign-in page with a headless
+browser** ([Nightmare](https://github.com/segmentio/nightmare)), scraping cookies
++ CSRF, then calling a private `createReminder` endpoint. Every link in that chain
+has since broken:
 
-#### TODO
-- [X] Create Listener example
-- [ ] Save cookies and device info in FileSystem file to avoid login every time
+- **Nightmare is abandoned** (Electron-based, no release since ~2018) and won't run
+  on modern Node; the `request` dependency is also deprecated.
+- **Amazon's sign-in is now bot-protected** — CAPTCHA and (typically mandatory)
+  2FA/MFA make headless password login fail.
+- **The web app and private endpoints changed** — the old cookie/CSRF +
+  `/api/notifications/createReminder` flow no longer matches.
+
+In short: `login()` fails before anything else can happen. The scrape approach
+isn't fixable — the better news is the gap it filled has since been closed.
+
+## Modern alternatives
+
+**Official — [Alexa Reminders API](https://developer.amazon.com/en-US/docs/alexa/smapi/alexa-reminders-overview.html)** (the proper API this project asked for, shipped 2018).
+Create reminders from an Alexa **skill** via `POST /v1/alerts/reminders` with the
+`alexa::alerts:reminders:skill:readwrite` permission. Skill-scoped: the user
+enables your skill and grants permission, and your skill manages reminders it
+created. ([REST reference](https://developer.amazon.com/en-US/docs/alexa/smapi/alexa-reminders-api-reference.html))
+
+**Unofficial / personal automation — [`alexa-remote2`](https://www.npmjs.com/package/alexa-remote2)** (actively maintained).
+Handles modern Amazon auth (proxy login that survives MFA, token refresh) and
+supports **reminders, notifications, announcements, and TTS** on your own devices.
+It's what Home Assistant's `alexa_media_player` and ioBroker use — the spiritual
+successor to this project for "remind/announce on my own Echo from a script."
+
+## License
+
+MIT

--- a/alexa-reminders.js
+++ b/alexa-reminders.js
@@ -1,3 +1,15 @@
+// DEPRECATED (2026): this library no longer works. It relied on scripting the
+// alexa.amazon.com sign-in page with a headless browser, which Amazon now blocks
+// (bot detection + 2FA), on top of abandoned dependencies (Nightmare, request).
+// Use the official Alexa Reminders API
+//   https://developer.amazon.com/en-US/docs/alexa/smapi/alexa-reminders-overview.html
+// or, for personal automation, alexa-remote2
+//   https://www.npmjs.com/package/alexa-remote2
+console.warn(
+  '[alexa-reminders] DEPRECATED and non-functional — see the README. ' +
+  'Use the official Alexa Reminders API or the alexa-remote2 package instead.'
+)
+
 var request = require('request')
 var Nightmare = require('nightmare')
 var nightmare = Nightmare({ show: false })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alexa-reminders",
   "version": "1.0.1",
-  "description": "",
+  "description": "DEPRECATED (2026) — no longer works. Use the official Alexa Reminders API or alexa-remote2. See README.",
   "main": "alexa-reminders.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This library's approach is **dead at the foundation** and can't be revived, so this marks it deprecated and signposts users to the modern paths.

## Why it no longer works
It logged in by scripting the `alexa.amazon.com` sign-in page with a headless browser (Nightmare), scraping cookies + CSRF, then calling a private `createReminder` endpoint. Every link broke:
- **Nightmare** abandoned (~2018, Electron-based, won't run on modern Node); `request` deprecated.
- **Amazon sign-in** is now bot-protected (CAPTCHA + typically mandatory 2FA) — headless password login fails.
- **Endpoints/web app changed** — old cookie/CSRF + `/api/notifications/createReminder` flow no longer matches.

`login()` fails before anything else, so the package is non-functional.

## What this PR does
- README rewritten as a clear **deprecation notice** explaining the breakage.
- Runtime `console.warn` on require, pointing to alternatives.
- `package.json` description marked DEPRECATED.

## Modern alternatives (in the README)
- **Official:** [Alexa Reminders API](https://developer.amazon.com/en-US/docs/alexa/smapi/alexa-reminders-overview.html) (the proper API this repo asked for — shipped 2018; skill-scoped).
- **Personal automation:** [`alexa-remote2`](https://www.npmjs.com/package/alexa-remote2) (maintained; modern auth + reminders/announce/TTS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)